### PR TITLE
Use HTTP response code provided by LinkedIn

### DIFF
--- a/allauth/socialaccount/providers/linkedin_oauth2/views.py
+++ b/allauth/socialaccount/providers/linkedin_oauth2/views.py
@@ -27,6 +27,7 @@ class LinkedInOAuth2Adapter(OAuth2Adapter):
         fields = self.get_provider().get_profile_fields()
         url = self.profile_url + ':(%s)?format=json' % ','.join(fields)
         resp = requests.get(url, params={'oauth2_access_token': token.token})
+        resp.raise_for_status()        
         return resp.json()
 
 


### PR DESCRIPTION
Similar to https://github.com/pennersr/django-allauth/commit/8705514dc164577f801cdacb5c46623c8cb9909b but for LinkedIn
- If LinkedIn responds with  a 401 in case of an invalid token,
  raise an `HTTPError` (resp.raise_for_status) to handle the
  exception correctly instead of the current Http500 status
  because of a `KeyError`.